### PR TITLE
Exposing transaction function via index.ts

### DIFF
--- a/src/fx/index.ts
+++ b/src/fx/index.ts
@@ -1,4 +1,4 @@
 export {ServiceStore} from "./ServiceStore";
 export {AppStore} from "./AppStore";
-export {Activity} from "./decorators";
+export {Activity, transaction} from "./decorators";
 export {TransactionScope} from "./TransactionScope";


### PR DESCRIPTION
Hi there,

While creating an Activity with a delayed transaction (`beginTransaction: false`) I noticed that the `transaction` syntax is not exported thus unavailable. I added it to index.ts - hope this helps.